### PR TITLE
GYM-31: Update render.yaml infrastructure configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,11 @@
 services:
-  # 1. Render Web Service (Paid, always-on Node.js API backend hosting Express/Fastify, WebSockets, background billing crons, IoT triggers, and aggregators)
+  # 1. Render Web Service (Free, always-on Node.js API backend hosting Express/Fastify, WebSockets, background billing crons, IoT triggers, and aggregators)
   - type: web
     name: gym-backend-core
     env: node
-    plan: starter
-    buildCommand: npm install && npm run build
-    startCommand: npm start
+    plan: free
+    buildCommand: cd src/backend && npm install
+    startCommand: cd src/backend && node index.js
     envVars:
       - key: NODE_ENV
         value: production
@@ -14,5 +14,5 @@ services:
   - type: web
     name: gym-frontend-app
     env: static
-    buildCommand: npm install && npm run build
-    staticPublishPath: ./out
+    buildCommand: cd src/frontend && npm install && npm run build
+    staticPublishPath: src/frontend/out


### PR DESCRIPTION
This PR addresses GYM-31 by updating the `render.yaml` infrastructure configuration. It specifies exactly two Render deployments, configuring the backend for the free tier and nesting the commands properly inside `src/backend` and `src/frontend` to accommodate the monorepo architecture.

---
*PR created automatically by Jules for task [3634660385006950276](https://jules.google.com/task/3634660385006950276) started by @Merite-M*