### PR TITLE
feat(pos): Implement shift management and member tab tracking

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -97,6 +97,7 @@ app.post('/api/checkin', async (req, res) => {
        return res.status(500).json({ error: 'Supabase not configured' });
     }
 
+
     // Check profile
     const { data: profile, error: profileError } = await supabase
       .from('profiles')
@@ -108,6 +109,39 @@ app.post('/api/checkin', async (req, res) => {
     if (profileError || !profile) {
        return res.status(404).json({ error: 'Profile not found' });
     }
+
+    if (profile.status === 'debtor') {
+        await supabase.from('check_ins').insert({
+            tenant_id,
+            profile_id,
+            device_id: device_id || null,
+            access_method: access_method || 'manual_override',
+            status: 'denied_debt'
+        });
+        return res.status(200).json({ success: true, status: 'denied_debt', reason: 'Account locked due to outstanding debt' });
+    }
+
+    // Check member tab balance
+    const { data: tab } = await supabase
+        .from('member_tabs')
+        .select('balance')
+        .eq('profile_id', profile_id)
+        .eq('tenant_id', tenant_id)
+        .single();
+
+    if (tab && parseFloat(tab.balance) > 0) {
+        // Here we could either deny entry or issue a warning based on tenant policy.
+        // For now, let's issue a warning.
+        await supabase.from('check_ins').insert({
+            tenant_id,
+            profile_id,
+            device_id: device_id || null,
+            access_method: access_method || 'manual_override',
+            status: 'warning'
+        });
+        return res.status(200).json({ success: true, status: 'warning', reason: `Outstanding tab balance: ${parseFloat(tab.balance).toFixed(2)}` });
+    }
+
 
     if (!profile.waiver_signed) {
         // Record denied checkin

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -98,6 +98,7 @@ app.post('/api/checkin', async (req, res) => {
     }
 
 
+
     // Check profile
     const { data: profile, error: profileError } = await supabase
       .from('profiles')
@@ -110,15 +111,12 @@ app.post('/api/checkin', async (req, res) => {
        return res.status(404).json({ error: 'Profile not found' });
     }
 
+    let finalStatus = 'approved';
+    let reasons = [];
+
     if (profile.status === 'debtor') {
-        await supabase.from('check_ins').insert({
-            tenant_id,
-            profile_id,
-            device_id: device_id || null,
-            access_method: access_method || 'manual_override',
-            status: 'denied_debt'
-        });
-        return res.status(200).json({ success: true, status: 'denied_debt', reason: 'Account locked due to outstanding debt' });
+        finalStatus = 'denied_debt';
+        reasons.push('Account locked due to outstanding debt');
     }
 
     // Check member tab balance
@@ -130,47 +128,25 @@ app.post('/api/checkin', async (req, res) => {
         .single();
 
     if (tab && parseFloat(tab.balance) > 0) {
-        // Here we could either deny entry or issue a warning based on tenant policy.
-        // For now, let's issue a warning.
-        await supabase.from('check_ins').insert({
-            tenant_id,
-            profile_id,
-            device_id: device_id || null,
-            access_method: access_method || 'manual_override',
-            status: 'warning'
-        });
-        return res.status(200).json({ success: true, status: 'warning', reason: `Outstanding tab balance: ${parseFloat(tab.balance).toFixed(2)}` });
+        if (finalStatus === 'approved') finalStatus = 'warning';
+        reasons.push(`Outstanding tab balance: ${parseFloat(tab.balance).toFixed(2)}`);
     }
-
 
     if (!profile.waiver_signed) {
-        // Record denied checkin
-        await supabase.from('check_ins').insert({
-            tenant_id,
-            profile_id,
-            device_id: device_id || null,
-            access_method: access_method || 'manual_override',
-            status: 'warning' // Or a specific denied status, let's use warning as per spec 'Liability Waiver Unsigned'
-        });
-        return res.status(200).json({ success: true, status: 'warning', reason: 'Liability Waiver Unsigned' });
+        if (finalStatus === 'approved') finalStatus = 'warning';
+        reasons.push('Liability Waiver Unsigned');
     }
 
-    // Check membership status logic can go here (simplified for now)
-
     // Check if waiver is older than 1 year
-    const waiverDate = new Date(profile.waiver_signed_at);
-    const oneYearAgo = new Date();
-    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+    if (profile.waiver_signed_at) {
+        const waiverDate = new Date(profile.waiver_signed_at);
+        const oneYearAgo = new Date();
+        oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
 
-    if (waiverDate < oneYearAgo) {
-        await supabase.from('check_ins').insert({
-            tenant_id,
-            profile_id,
-            device_id: device_id || null,
-            access_method: access_method || 'manual_override',
-            status: 'warning'
-        });
-        return res.status(200).json({ success: true, status: 'warning', reason: 'Liability Waiver Expired (Needs Renewal)' });
+        if (waiverDate < oneYearAgo) {
+            if (finalStatus === 'approved') finalStatus = 'warning';
+            reasons.push('Liability Waiver Expired (Needs Renewal)');
+        }
     }
 
     const { data: checkin, error: checkinError } = await supabase.from('check_ins').insert({
@@ -178,16 +154,22 @@ app.post('/api/checkin', async (req, res) => {
         profile_id,
         device_id: device_id || null,
         access_method: access_method || 'manual_override',
-        status: 'approved'
+        status: finalStatus
     }).select();
 
     if (checkinError) {
         return res.status(500).json({ error: checkinError.message });
     }
 
-    res.status(200).json({ success: true, status: 'approved', checkin: checkin[0] });
+    res.status(200).json({
+        success: true,
+        status: finalStatus,
+        checkin: checkin[0],
+        reason: reasons.length > 0 ? reasons.join('; ') : undefined
+    });
 
   } catch (error) {
+
      console.error("Checkin error:", error);
      res.status(500).json({ error: 'Internal server error' });
   }

--- a/src/backend/pos.js
+++ b/src/backend/pos.js
@@ -267,4 +267,80 @@ router.post('/shift/end', async (req, res) => {
     }
 });
 
+
+// Fetch member tab balance
+router.get('/member_tab/:profile_id', async (req, res) => {
+  if (!supabase) return res.status(500).json({error: "Supabase config missing"});
+  try {
+    const { profile_id } = req.params;
+    const { tenant_id } = req.query;
+
+    if (!profile_id || !tenant_id) {
+       return res.status(400).json({ error: 'Missing profile_id or tenant_id' });
+    }
+
+    const { data, error } = await supabase
+      .from('member_tabs')
+      .select('balance')
+      .eq('profile_id', profile_id)
+      .eq('tenant_id', tenant_id)
+      .single();
+
+    if (error && error.code !== 'PGRST116') { // PGRST116 is no rows returned
+        throw error;
+    }
+
+    res.json({ balance: data ? parseFloat(data.balance) : 0 });
+  } catch (error) {
+    console.error("Tab fetch error:", error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Shift X-Report
+router.get('/shift/:shift_id/x-report', async (req, res) => {
+    if (!supabase) return res.status(500).json({error: "Supabase config missing"});
+    try {
+        const { shift_id } = req.params;
+
+        const { data: shift, error: shiftError } = await supabase
+            .from('shift_ledgers')
+            .select('*')
+            .eq('id', shift_id)
+            .single();
+
+        if (shiftError) throw shiftError;
+
+        const { data: payments, error: paymentsError } = await supabase
+            .from('payments')
+            .select('amount, method')
+            .eq('shift_id', shift_id);
+
+        if (paymentsError) throw paymentsError;
+
+        const totals = {
+            cash: 0,
+            card: 0,
+            momo: 0,
+            member_tab: 0,
+            bank_transfer: 0
+        };
+
+        payments.forEach(p => {
+            if (totals[p.method] !== undefined) {
+                totals[p.method] += parseFloat(p.amount);
+            }
+        });
+
+        res.json({
+            shift,
+            totals,
+            expected_cash: parseFloat(shift.expected_cash)
+        });
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+
 module.exports = router;

--- a/src/backend/pos.js
+++ b/src/backend/pos.js
@@ -10,6 +10,31 @@ if (supabaseUrl && supabaseKey) {
   supabase = createClient(supabaseUrl, supabaseKey);
 }
 
+
+// Get current shift status
+router.get('/shift/status', async (req, res) => {
+    if (!supabase) return res.status(500).json({error: "Supabase config missing"});
+    try {
+        const { tenant_id } = req.query;
+        if (!tenant_id) return res.status(400).json({ error: 'Missing tenant_id' });
+
+        const { data, error } = await supabase
+            .from('shift_ledgers')
+            .select('*')
+            .eq('tenant_id', tenant_id)
+            .eq('status', 'open')
+            .order('created_at', { ascending: false })
+            .limit(1)
+            .single();
+
+        if (error && error.code !== 'PGRST116') throw error;
+
+        res.json(data || null);
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
 // Fetch products
 router.get('/products', async (req, res) => {
   if (!supabase) return res.status(500).json({error: "Supabase config missing"});
@@ -177,32 +202,31 @@ router.post('/checkout', async (req, res) => {
       }
     }
 
+
     // Record Payment
-    if (method !== 'member_tab') {
-      const paymentStatus = method === 'momo' ? 'pending' : 'completed';
+    const paymentStatus = (method === 'momo' || method === 'member_tab') ? 'pending' : 'completed';
 
-      const { error: paymentError } = await supabase.from('payments').insert({
-        tenant_id,
-        invoice_id: invoice.id,
-        profile_id,
-        shift_id: method === 'cash' ? shift_id : null,
-        amount: totalAmount,
-        method: method,
-        status: paymentStatus
-      });
-      if (paymentError) throw paymentError;
+    const { error: paymentError } = await supabase.from('payments').insert({
+      tenant_id,
+      invoice_id: invoice.id,
+      profile_id,
+      shift_id: (method === 'cash' || method === 'member_tab' || method === 'momo') ? shift_id : null, // Record shift for tab to show in X-report
+      amount: totalAmount,
+      method: method,
+      status: paymentStatus
+    });
+    if (paymentError) throw paymentError;
 
-      // If cash, update shift ledger expected cash
-      if (method === 'cash' && shift_id) {
-         const { data: shift, error: shiftFetchError } = await supabase.from('shift_ledgers').select('expected_cash').eq('id', shift_id).single();
-         if (shiftFetchError) throw shiftFetchError;
+    // If cash, update shift ledger expected cash
+    if (method === 'cash' && shift_id) {
+       const { data: shift, error: shiftFetchError } = await supabase.from('shift_ledgers').select('expected_cash').eq('id', shift_id).single();
+       if (shiftFetchError) throw shiftFetchError;
 
-         if (shift) {
-             const newExpected = parseFloat(shift.expected_cash || 0) + totalAmount;
-             const { error: shiftUpdateError } = await supabase.from('shift_ledgers').update({ expected_cash: newExpected }).eq('id', shift_id);
-             if (shiftUpdateError) throw shiftUpdateError;
-         }
-      }
+       if (shift) {
+           const newExpected = parseFloat(shift.expected_cash || 0) + totalAmount;
+           const { error: shiftUpdateError } = await supabase.from('shift_ledgers').update({ expected_cash: newExpected }).eq('id', shift_id);
+           if (shiftUpdateError) throw shiftUpdateError;
+       }
     }
 
     res.json({ success: true, invoice_id: invoice.id, total: totalAmount });
@@ -240,8 +264,12 @@ router.post('/shift/end', async (req, res) => {
 
         if (shiftFetchError) throw shiftFetchError;
 
+
         let status = 'closed';
-        if (parseFloat(actual_cash) !== parseFloat(shift.expected_cash)) {
+        const expected = parseFloat(shift.expected_cash);
+        const actual = parseFloat(actual_cash);
+        if (Math.abs(expected - actual) > 0.01) {
+
             status = 'discrepancy';
             // Alert logic here
             const { error: auditError } = await supabase.from('audit_logs').insert({
@@ -297,16 +325,21 @@ router.get('/member_tab/:profile_id', async (req, res) => {
   }
 });
 
+
 // Shift X-Report
 router.get('/shift/:shift_id/x-report', async (req, res) => {
     if (!supabase) return res.status(500).json({error: "Supabase config missing"});
     try {
         const { shift_id } = req.params;
+        const { tenant_id } = req.query;
+
+        if (!tenant_id) return res.status(400).json({ error: 'Missing tenant_id' });
 
         const { data: shift, error: shiftError } = await supabase
             .from('shift_ledgers')
             .select('*')
             .eq('id', shift_id)
+            .eq('tenant_id', tenant_id)
             .single();
 
         if (shiftError) throw shiftError;
@@ -314,7 +347,9 @@ router.get('/shift/:shift_id/x-report', async (req, res) => {
         const { data: payments, error: paymentsError } = await supabase
             .from('payments')
             .select('amount, method')
-            .eq('shift_id', shift_id);
+            .eq('shift_id', shift_id)
+            .eq('tenant_id', tenant_id);
+
 
         if (paymentsError) throw paymentsError;
 

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
+        "@next/eslint-plugin-next": "^16.3.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -25,6 +25,7 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "^16.3.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/frontend/src/app/pos/page.tsx
+++ b/src/frontend/src/app/pos/page.tsx
@@ -41,8 +41,12 @@ export default function POSTerminal() {
     const [activeCategory, setActiveCategory] = useState<string>('ALL');
     const [profiles, setProfiles] = useState<Profile[]>([]);
     const [selectedProfile, setSelectedProfile] = useState<string>('');
+    const [memberTabBalance, setMemberTabBalance] = useState<number>(0);
     const [tillStatus, setTillStatus] = useState<Shift | null>(null); // For cash till challenge
     const [isCheckingOut, setIsCheckingOut] = useState(false);
+    const [showShiftModal, setShowShiftModal] = useState<boolean>(false);
+    const [shiftReport, setShiftReport] = useState<any>(null);
+    const [actualCash, setActualCash] = useState<string>('');
 
     useEffect(() => {
         const fetchInitialData = async () => {
@@ -93,6 +97,42 @@ export default function POSTerminal() {
         supabase.removeChannel(channel);
       };
     }, []);
+
+
+    useEffect(() => {
+        const fetchTabBalance = async () => {
+            if (selectedProfile) {
+                const { data: tenant } = await supabase.from('tenants').select('id').limit(1).single();
+                if (tenant) {
+                    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/api/pos/member_tab/${selectedProfile}?tenant_id=${tenant.id}`);
+                    if (res.ok) {
+                        const data = await res.json();
+                        setMemberTabBalance(data.balance);
+                    }
+                }
+            } else {
+                setMemberTabBalance(0);
+            }
+        };
+        fetchTabBalance();
+    }, [selectedProfile]);
+
+
+
+    const fetchXReport = async () => {
+        if (!tillStatus) return;
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/api/pos/shift/${tillStatus.id}/x-report`);
+        if (res.ok) {
+            setShiftReport(await res.json());
+        }
+    };
+
+    useEffect(() => {
+        if (showShiftModal && tillStatus) {
+            fetchXReport();
+        }
+    }, [showShiftModal, tillStatus]);
+
 
     const filteredProducts = activeCategory === 'ALL' ? products : products.filter(p => p.category === activeCategory);
 
@@ -187,6 +227,34 @@ export default function POSTerminal() {
         setIsCheckingOut(false);
     };
 
+
+    const handleCloseShift = async () => {
+        if (!tillStatus || !actualCash) return;
+        try {
+            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/api/pos/shift/end`, {
+                 method: 'POST',
+                 headers: { 'Content-Type': 'application/json' },
+                 body: JSON.stringify({ shift_id: tillStatus.id, actual_cash: parseFloat(actualCash) })
+            });
+            const result = await res.json();
+
+            if (result.status === 'discrepancy') {
+                 alert(`Shift closed with discrepancy. Expected: ${result.expected_cash}, Actual: ${result.actual_cash}`);
+            } else {
+                 alert('Shift closed successfully.');
+            }
+
+            setTillStatus(null);
+            setShowShiftModal(false);
+            setShiftReport(null);
+            setActualCash('');
+        } catch (error) {
+            console.error(error);
+            alert("Error closing shift");
+        }
+    };
+
+
     if (isPosEnabled === null) {
         return <div className="flex h-screen items-center justify-center font-body-base bg-canvas-bg text-primary">Loading POS Terminal...</div>;
     }
@@ -252,6 +320,13 @@ export default function POSTerminal() {
               <h2 className="text-headline-md font-bold text-primary tracking-tight">Point of Sale</h2>
             </div>
             <div className="flex items-center gap-4">
+              <button
+                  onClick={() => setShowShiftModal(true)}
+                  className="px-4 py-2 bg-surface-container border border-border-hairline rounded-lg text-body-dense font-medium text-primary hover:bg-surface-muted transition-colors flex items-center gap-2"
+              >
+                  <span className="material-symbols-outlined text-[18px]">point_of_sale</span>
+                  {tillStatus ? 'Till Management' : 'Open Till'}
+              </button>
               <div className="flex items-center gap-2 border-l border-border-hairline pl-4 ml-2">
                 <button className="text-text-muted hover:text-on-surface transition-colors p-1.5 rounded-full hover:bg-surface-muted">
                   <span className="material-symbols-outlined">notifications</span>
@@ -321,6 +396,14 @@ export default function POSTerminal() {
                     </select>
                   </div>
                 </div>
+                {selectedProfile && (
+                  <div className="mt-3 p-3 bg-surface-container-lowest rounded-lg border border-border-hairline flex justify-between items-center">
+                      <span className="text-body-dense font-medium text-text-muted">Account Tab Balance:</span>
+                      <span className={`font-mono-id font-bold ${memberTabBalance > 0 ? 'text-danger-crimson' : 'text-primary'}`}>
+                          ${memberTabBalance.toFixed(2)}
+                      </span>
+                  </div>
+                )}
               </div>
 
               {/* Cart Items */}
@@ -396,7 +479,84 @@ export default function POSTerminal() {
               </div>
             </div>
           </div>
-        </div>
+
+        {/* Shift Management Modal */}
+        {showShiftModal && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+                <div className="bg-surface rounded-xl shadow-xl border border-border-hairline w-full max-w-md overflow-hidden">
+                    <div className="px-6 py-4 border-b border-border-hairline flex justify-between items-center bg-canvas-bg">
+                        <h3 className="font-bold text-primary text-body-base">
+                            {tillStatus ? 'Shift Management (X-Report)' : 'Open New Shift'}
+                        </h3>
+                        <button onClick={() => setShowShiftModal(false)} className="text-text-muted hover:text-primary">
+                            <span className="material-symbols-outlined">close</span>
+                        </button>
+                    </div>
+                    <div className="p-6">
+                        {!tillStatus ? (
+                             <div className="text-center">
+                                 <p className="text-body-dense text-text-muted mb-4">You need to open a shift to process cash transactions.</p>
+                                 <button
+                                     onClick={() => { setShowShiftModal(false); handleCheckout('cash'); }}
+                                     className="px-6 py-3 bg-primary text-on-primary font-bold rounded-lg hover:bg-primary/90 transition-colors w-full"
+                                 >
+                                     Open Shift Now
+                                 </button>
+                             </div>
+                        ) : (
+                             <div>
+                                 {shiftReport ? (
+                                     <div className="space-y-4">
+                                         <div className="grid grid-cols-2 gap-4">
+                                             <div className="p-3 bg-canvas-bg rounded-lg border border-border-hairline">
+                                                 <p className="text-[11px] font-bold text-text-muted uppercase tracking-widest mb-1">Cash Sales</p>
+                                                 <p className="font-mono-id font-bold text-primary">${(shiftReport.totals?.cash || 0).toFixed(2)}</p>
+                                             </div>
+                                             <div className="p-3 bg-canvas-bg rounded-lg border border-border-hairline">
+                                                 <p className="text-[11px] font-bold text-text-muted uppercase tracking-widest mb-1">MoMo Sales</p>
+                                                 <p className="font-mono-id font-bold text-primary">${(shiftReport.totals?.momo || 0).toFixed(2)}</p>
+                                             </div>
+                                             <div className="p-3 bg-canvas-bg rounded-lg border border-border-hairline">
+                                                 <p className="text-[11px] font-bold text-text-muted uppercase tracking-widest mb-1">Tab Charges</p>
+                                                 <p className="font-mono-id font-bold text-primary">${(shiftReport.totals?.member_tab || 0).toFixed(2)}</p>
+                                             </div>
+                                             <div className="p-3 bg-surface-muted rounded-lg border border-border-hairline">
+                                                 <p className="text-[11px] font-bold text-text-muted uppercase tracking-widest mb-1">Expected Cash In Till</p>
+                                                 <p className="font-mono-id font-bold text-primary text-lg">${(shiftReport.expected_cash || 0).toFixed(2)}</p>
+                                             </div>
+                                         </div>
+
+                                         <div className="pt-4 border-t border-border-hairline mt-4">
+                                             <p className="font-bold text-primary mb-2 text-sm">Z-Report: Close Shift</p>
+                                             <div className="flex gap-2">
+                                                 <input
+                                                     type="number"
+                                                     placeholder="Counted Cash ($)"
+                                                     value={actualCash}
+                                                     onChange={e => setActualCash(e.target.value)}
+                                                     className="flex-1 bg-surface-container-lowest border border-border-hairline rounded-lg px-3 py-2 text-body-base text-primary font-mono-id"
+                                                 />
+                                                 <button
+                                                     disabled={!actualCash}
+                                                     onClick={handleCloseShift}
+                                                     className="px-4 py-2 bg-danger-crimson text-white font-bold rounded-lg hover:bg-danger-crimson/90 transition-colors disabled:opacity-50"
+                                                 >
+                                                     Close Till
+                                                 </button>
+                                             </div>
+                                         </div>
+                                     </div>
+                                 ) : (
+                                     <p className="text-center text-text-muted">Loading report...</p>
+                                 )}
+                             </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+        )}
+
+      </div>
       </div>
     );
 }

--- a/src/frontend/src/app/pos/page.tsx
+++ b/src/frontend/src/app/pos/page.tsx
@@ -238,6 +238,11 @@ export default function POSTerminal() {
             });
             const result = await res.json();
 
+            if (!res.ok) {
+                 alert(`Error closing shift: ${result.error || 'Unknown error'}`);
+                 return;
+            }
+
             if (result.status === 'discrepancy') {
                  alert(`Shift closed with discrepancy. Expected: ${result.expected_cash}, Actual: ${result.actual_cash}`);
             } else {

--- a/src/frontend/src/app/pos/page.tsx
+++ b/src/frontend/src/app/pos/page.tsx
@@ -121,7 +121,8 @@ export default function POSTerminal() {
 
     const fetchXReport = async () => {
         if (!tillStatus) return;
-        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/api/pos/shift/${tillStatus.id}/x-report`);
+        const { data: _tenant } = await supabase.from('tenants').select('id').limit(1).single();
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/api/pos/shift/${tillStatus.id}/x-report?tenant_id=${_tenant?.id}`);
         if (res.ok) {
             setShiftReport(await res.json());
         }
@@ -169,26 +170,41 @@ export default function POSTerminal() {
 
     const cartTotal = cart.reduce((sum, item) => sum + (item.sell_price * item.quantity), 0);
 
+
+    const openShift = async () => {
+        const startingCash = prompt("Audit: Please enter current physical till cash balance to open shift");
+        if (!startingCash) return null;
+
+        const { data: tenant } = await supabase.from('tenants').select('id').limit(1).single();
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/api/pos/shift/start`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ tenant_id: tenant?.id, staff_id: null, starting_cash: parseFloat(startingCash) })
+        });
+
+        if (res.ok) {
+            const shift = await res.json();
+            setTillStatus(shift);
+            alert("Shift Opened successfully.");
+            return shift;
+        }
+        return null;
+    };
+
+
+
     const handleCheckout = async (method: string) => {
         if (cart.length === 0) return;
         if (method === 'member_tab' && !selectedProfile) {
             alert("Please select a member to charge to tab");
             return;
         }
-        if (method === 'cash' && !tillStatus) {
-            const startingCash = prompt("Audit: Please enter current physical till cash balance to open shift");
-            if (!startingCash) return;
-            // Open shift
-            const { data: tenant } = await supabase.from('tenants').select('id').limit(1).single();
-            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/api/pos/shift/start`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ tenant_id: tenant?.id, staff_id: null, starting_cash: parseFloat(startingCash) })
-            });
-            const shift = await res.json();
-            setTillStatus(shift);
-            alert("Shift Opened. Proceeding with checkout.");
-            return; // Requires them to click checkout again after shift opens
+
+        let currentShift = tillStatus;
+        if (method === 'cash' && !currentShift) {
+            currentShift = await openShift();
+            if (!currentShift) return;
+            // The flow can proceed now that the shift is opened
         }
 
         setIsCheckingOut(true);
@@ -198,12 +214,11 @@ export default function POSTerminal() {
                  tenant_id: tenant?.id,
                  profile_id: selectedProfile || null,
                  method,
-                 shift_id: tillStatus ? tillStatus.id : null,
+                 shift_id: currentShift ? currentShift.id : null,
                  staff_id: null, // Would be current user
                  items: cart.map(item => ({ product_id: item.id, quantity: item.quantity, sell_price: item.sell_price, name: item.name }))
              };
-
-             const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/api/pos/checkout`, {
+const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/api/pos/checkout`, {
                  method: 'POST',
                  headers: { 'Content-Type': 'application/json' },
                  body: JSON.stringify(payload)
@@ -237,11 +252,6 @@ export default function POSTerminal() {
                  body: JSON.stringify({ shift_id: tillStatus.id, actual_cash: parseFloat(actualCash) })
             });
             const result = await res.json();
-
-            if (!res.ok) {
-                 alert(`Error closing shift: ${result.error || 'Unknown error'}`);
-                 return;
-            }
 
             if (result.status === 'discrepancy') {
                  alert(`Shift closed with discrepancy. Expected: ${result.expected_cash}, Actual: ${result.actual_cash}`);
@@ -502,7 +512,7 @@ export default function POSTerminal() {
                              <div className="text-center">
                                  <p className="text-body-dense text-text-muted mb-4">You need to open a shift to process cash transactions.</p>
                                  <button
-                                     onClick={() => { setShowShiftModal(false); handleCheckout('cash'); }}
+                                     onClick={async () => { await openShift(); }}
                                      className="px-6 py-3 bg-primary text-on-primary font-bold rounded-lg hover:bg-primary/90 transition-colors w-full"
                                  >
                                      Open Shift Now


### PR DESCRIPTION
I have implemented the requested POS features regarding shift management and member tab accounting to handle edge cases for GYM-8.

Changes included:
- Exposed a new backend endpoint `/api/pos/member_tab/:profile_id` to fetch accrued revenue/tabs.
- Added dynamic member tab fetching on the Point of Sale UI based on the selected checkout client.
- Added X-Report processing to the backend for live snapshot views of till cash.
- Generated the Till Management / Shift End modal directly inside `src/frontend/src/app/pos/page.tsx`.
- Overhauled the `api/checkin` endpoint to inspect the `member_tabs` balance along with the explicit `profiles.status == debtor`. Now appropriately issues warning logs for partial accrued revenue and denies entry for fully marked debtors.

The Linear ticket GYM-8 was updated via comments and set to 'In Progress' as some administrative views of this financial data were requested in the epic scope but belong out of the direct POS scope. Everything compiles and tests successfully.

---
*PR created automatically by Jules for task [18289464105604150547](https://jules.google.com/task/18289464105604150547) started by @Merite-M*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/merite-m/gymproject/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->