### PR TITLE
🧹 Remove leftover console.log in cron.js

### DIFF
--- a/src/backend/cron.js
+++ b/src/backend/cron.js
@@ -13,7 +13,6 @@ function initCron(supabase) {
     // Run every minute
     cron.schedule('* * * * *', async () => {
         if (isRunning) {
-            console.log("Cron job is already running. Skipping this tick.");
             return;
         }
 


### PR DESCRIPTION
🎯 What: Removed the unnecessary `console.log("Cron job is already running. Skipping this tick.");` statement in `src/backend/cron.js`.
💡 Why: This log statement was printing every minute when the cron job was already running, cluttering the application logs and making it harder to spot real issues. Removing it improves the signal-to-noise ratio in the logs.
✅ Verification: Checked that there are no regressions.
✨ Result: Cleaner logs without unnecessary spam every minute.

---
*PR created automatically by Jules for task [14477284611121852513](https://jules.google.com/task/14477284611121852513) started by @Merite-M*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/merite-m/gymproject/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->