### PR TITLE
[EPIC-02 Core Data Model & RLS] Upgrade Supabase Schema for Two-Sided Corporate Wellness Network (GYM-64)

### DIFF
--- a/apps/web-gym-saas/src/types/database.ts
+++ b/apps/web-gym-saas/src/types/database.ts
@@ -311,3 +311,124 @@ export interface StaffTaskItem {
   due_date?: string | null;
   created_at?: string;
 }
+
+export type PlanTier = 'Standard' | 'Premium' | 'Elite';
+export type CorporateEmployeeStatus = 'Active' | 'Suspended' | 'Terminated';
+export type WellnessCategory = 'Gym' | 'Swimming Pool' | 'Sauna/Steam' | 'Sports Club' | 'Yoga Studio';
+export type ProviderTierLevel = 'Standard' | 'Premium' | 'Luxury';
+export type NetworkPayoutStatus = 'Pending' | 'Approved' | 'Capped_Zero_Rate' | 'Settled' | 'Denied';
+
+export interface CorporateEmployer {
+  id: string;
+  tenant_id: string;
+  company_name: string;
+  tax_id_ebm: string;
+  plan_tier: PlanTier;
+  monthly_budget_rwf: number;
+  employer_subsidy_percentage: number;
+  billing_cycle_day: number;
+  status: 'active' | 'suspended' | 'inactive';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CorporateEmployee {
+  id: string;
+  tenant_id: string;
+  employer_id: string;
+  user_id?: string | null;
+  profile_id?: string | null;
+  employee_code: string;
+  department?: string | null;
+  status: CorporateEmployeeStatus;
+  monthly_co_pay_limit_rwf: number;
+  created_at: string;
+  updated_at: string;
+  employer?: CorporateEmployer;
+  profile?: Profile | null;
+}
+
+export interface WellnessProvider {
+  id: string;
+  tenant_id: string;
+  provider_name: string;
+  category: WellnessCategory;
+  tier_level: ProviderTierLevel;
+  payout_bank_account?: string | null;
+  spenn_wallet_msisdn?: string | null;
+  status: 'active' | 'suspended' | 'inactive';
+  created_at: string;
+  updated_at: string;
+  facilities?: ProviderFacility[];
+}
+
+export interface ProviderFacility {
+  id: string;
+  tenant_id: string;
+  provider_id: string;
+  facility_name: string;
+  category: WellnessCategory;
+  tier_level: ProviderTierLevel;
+  base_payout_per_visit_rwf: number;
+  monthly_visit_cap_per_user: number;
+  geofence_lat?: number | null;
+  geofence_lng?: number | null;
+  geofence_radius_meters: number;
+  payout_bank_account?: string | null;
+  spenn_wallet_msisdn?: string | null;
+  status: 'active' | 'suspended' | 'inactive';
+  created_at: string;
+  updated_at: string;
+  provider?: WellnessProvider;
+}
+
+export interface NetworkCheckin {
+  id: string;
+  tenant_id: string;
+  employee_id: string;
+  facility_id: string;
+  verified_at: string;
+  totp_token_used?: string | null;
+  payout_amount_rwf: number;
+  payout_status: NetworkPayoutStatus;
+  is_co_pay_triggered: boolean;
+  created_at: string;
+  employee?: CorporateEmployee;
+  facility?: ProviderFacility;
+}
+
+export interface NetworkCheckinVerificationResult {
+  success: boolean;
+  checkin_id?: string;
+  employee_id?: string;
+  facility_id?: string;
+  facility_name?: string;
+  visit_count_this_month?: number;
+  monthly_visit_cap?: number;
+  payout_amount_rwf?: number;
+  payout_status?: NetworkPayoutStatus;
+  is_co_pay_triggered?: boolean;
+  verified_at?: string;
+  error?: string;
+  code?: string;
+  last_checkin_at?: string;
+}
+
+export interface MonthlyProviderPayoutSummary {
+  success: boolean;
+  facility_id: string;
+  facility_name: string;
+  provider_id: string;
+  period_year: number;
+  period_month: number;
+  total_visits: number;
+  payable_visits: number;
+  capped_zero_rate_visits: number;
+  base_payout_per_visit_rwf: number;
+  total_payout_due_rwf: number;
+  payout_bank_account?: string | null;
+  spenn_wallet_msisdn?: string | null;
+  error?: string;
+  code?: string;
+}
+


### PR DESCRIPTION
## Description & Strategic Objective

Closes Linear issue **GYM-64** / GitHub issue #146.

Upgrades the Supabase PostgreSQL database schema to support a two-sided **B2B Corporate Wellness Network** ecosystem. The schema seamlessly decouples **Corporate Employers** (purchasing employee health benefits) from **Wellness Providers** (gyms, pools, studios receiving payouts for verified usage) while preserving existing single-gym SaaS capabilities under unified multi-tenant Row Level Security (RLS).

---

## Key Schema & Relational Changes

### 1. New Normalized Relational Tables (3NF/BCNF)
- **`corporate_employers`**: Corporate sponsor entity tracking company name, RRA EBM tax identification (`tax_id_ebm`), corporate plan tiers (`Standard`, `Premium`, `Elite`), monthly budgets, subsidy percentages (0–100%), and billing cycle days (1–31).
  - *Constraints*: `UNIQUE (tenant_id, tax_id_ebm)`, check constraints for non-negative budgets and valid numeric bounds.
- **`corporate_employees`**: Links corporate employers to member profiles and auth users without duplicating user identity information.
  - *Constraints*: `UNIQUE (employer_id, employee_code)`, `UNIQUE (employer_id, profile_id)`, and `UNIQUE (employer_id, user_id)`.
- **`wellness_providers`**: Parent network partner entities with categories (`Gym`, `Swimming Pool`, `Sauna/Steam`, `Sports Club`, `Yoga Studio`), tier levels, payout bank accounts, and SPENN wallet MSISDNs.
- **`provider_facilities`**: Physical branches/studios with geofences (`geofence_lat`, `geofence_lng`, `geofence_radius_meters`), per-visit payout rates (`base_payout_per_visit_rwf`), and monthly visit caps (`monthly_visit_cap_per_user`).
- **`network_checkins`**: Immutable verification ledger tracking TOTP tokens, automated payout statuses (`Approved`, `Capped_Zero_Rate`, `Settled`), and employee co-pay activations.

### 2. Multi-Tenant Row Level Security (RLS)
- Tenant staff/admin isolation via `get_user_tenant_id()`.
- Scoped visibility for Corporate HR Admins to view/manage their own employees and usage receipts.
- Scoped visibility for Wellness Provider Managers to view check-ins at their facilities.
- Scoped read-only access for individual employees to view their own check-ins and passes.

### 3. Database Helper RPC Functions
- **`verify_network_checkin(p_employee_id, p_facility_id, p_totp_token, p_override_co_pay)`**:
  - Enforces active status validation for employee, employer, and facility.
  - 5-minute anti-passback window to reject duplicate check-ins (`ANTI_PASSBACK_VIOLATION`).
  - Breakage cap evaluation: when monthly visits reach `monthly_visit_cap_per_user`, sets `payout_status = 'Capped_Zero_Rate'`, `payout_amount_rwf = 0.00`, and triggers `is_co_pay_triggered = true`.
- **`calculate_monthly_provider_payout(p_facility_id, p_year, p_month)`**:
  - Aggregates total visits, payable visits, zero-rate visits, and total payout due in RWF for clearing and settlement.

### 4. Frontend & Type Synchronization
- Updated `apps/web-gym-saas/src/types/database.ts` with typed interfaces for `CorporateEmployer`, `CorporateEmployee`, `WellnessProvider`, `ProviderFacility`, `NetworkCheckin`, and related RPC response models.

---

## Verification & Testing
- Executed end-to-end integration tests live in Supabase PostgreSQL:
  - Verified table creation, primary keys, foreign keys, and multi-column unique constraints.
  - Verified RPC check-in flow, anti-passback rejection, and cap/co-pay trigger logic.
  - Verified monthly clearing calculation aggregation accuracy.
- Branch: `mucyomerite/gym-64-epic-02-core-data-model-rls-upgrade-supabase-schema-for-two`